### PR TITLE
Use WiFiManager for WiFi connectivity instead of hardcoding SSID and …

### DIFF
--- a/v0.2/Firmware/LuchtLichtje/platformio.ini
+++ b/v0.2/Firmware/LuchtLichtje/platformio.ini
@@ -19,5 +19,5 @@ monitor_speed = 115200
 upload_speed = 115200
 lib_deps =
     ArduinoJSON@5
-
+    WiFiManager
 


### PR DESCRIPTION
…password.

Deze patch laat zien hoe je WiFiManager kan gebruiken voor het invoeren van de WiFi gegevens (SSID en wachtwoord) en het luftdaten id. Hierdoor hoeft de sketch dus niet meer aangepast te worden voor elke specifieke gebruiker.