### PR TITLE
Fix casing of library names.

### DIFF
--- a/v0.2/Firmware/LuchtLichtje/platformio.ini
+++ b/v0.2/Firmware/LuchtLichtje/platformio.ini
@@ -18,6 +18,6 @@ framework = arduino
 monitor_speed = 115200
 upload_speed = 115200
 lib_deps =
-    ArduinoJSON@5
-    WiFiManager
+    ArduinoJson@5
+    WifiManager
 


### PR DESCRIPTION
Using the proper name avoids platformio contacting the remote repository for each build.